### PR TITLE
Custom pagination key

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -36,7 +36,8 @@
   headings:{},
   pagination: {
     dropdown:false,
-    chunk:10
+    chunk:10,
+    key: 'count'
   }
 }
 }

--- a/lib/methods/set-data.js
+++ b/lib/methods/set-data.js
@@ -1,6 +1,7 @@
 module.exports =  function(data) {
   this.data = data.data;
-  this.count = data.count;
+  //this.count = data.count;
+  this.count = this.options.pagination.key.split('.').reduce(index, data);
 
   this.addCustomColumns();
 
@@ -8,4 +9,5 @@ module.exports =  function(data) {
     this.$dispatch('vue-tables.loaded',data);
   }.bind(this),0);
 
+  function index(obj,i) {return obj[i]}
 }


### PR DESCRIPTION
@matfish2 the current key expected in the server side response for pagination (count), does not corresponds to what most API return. I'd expect to see something more like:

```yml
{
    data: [],
    meta: {
        pagination: {
            "total": 6613,
            "count": 25,
            "per_page": 25,
            "current_page": 1,
            "total_pages": 265,
            "links": {
                "next": "http://localhost:8000/api/forum/posts?page=2"
            }
        }
    }
}
```

So, in this PR, I'm adding a possibility to configure that in your options (globally, per table, etc).

In the case of the prev. example, you would use it like this:

```js
Vue.use(VueTables.server, {pagination: {key: 'meta.pagination.total'}}); 
```

Let me know if you're interested on merging this, or if I should use my own fork for my projects. Thanks!