### PR TITLE
Eloquent example: use Input::only instead of Input::all

### DIFF
--- a/server/PHP/EloquentVueTables.php
+++ b/server/PHP/EloquentVueTables.php
@@ -9,7 +9,7 @@ Class EloquentVueTables  implements VueTablesInterface  {
 
   public function get($model, Array $fields) {
 
-    extract(Input::all());
+    extract(Input::only('query', 'limit', 'page', 'orderBy', 'ascending', 'byColumn'));
 
     $data = $model->select($fields);
 


### PR DESCRIPTION
Using `Input::only` instead of `Input::all` prevents the `extract` method from creating unwanted variables that may have been passed along in the query string. 