### PR TITLE
make parameter names of server table configurable

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -49,7 +49,15 @@ module.exports = function(source) {
       dropdown:false,
       chunk:10
     },
-    serverDataFieldName: 'data'
+    serverDataFieldName: 'data',
+    queryParams: {
+      query: 'query',
+      limit: 'limit',
+      orderBy: 'orderBy',
+      ascending: 'ascending',
+      page: 'page',
+      byColumn: 'byColumn'
+    }
   }
 }
 

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -1,56 +1,56 @@
- // Defaults are returned from a function to overcome caching issues which might cause data leakage between instances
+// Defaults are returned from a function to overcome caching issues which might cause data leakage between instances
 
- module.exports = function(source) {
+module.exports = function(source) {
   return {
-   dateColumns:[],
-   listColumns:{},
-   datepickerOptions:{
-    locale: {
-      cancelLabel:'Clear'
-    }
-   },
-   perPage:10,
-   perPageValues:[10,25,50,100],
-   params:{},
-   sortable:[],
-   trackBy:'$index',
-   filterable:false,
-   customFilters:[],
-   templates:{},
-   compileTemplates:false,
-   delay:500,
-   dateFormat:"DD/MM/YYYY",
-   toMomentFormat:false,
-   skin:"table-striped table-bordered table-hover",
-   columnsDisplay: {},
-   texts:{
-    count:"{count} Records",
-    filter:"Filter Results:",
-    filterPlaceholder:"Search query",
-    limit:"Records:",
-    page:"Page:",
-    noResults:"No matching records",
-    filterBy:"Filter by {column}",
-    loading:'Loading...',
-    defaultOption:'Select {column}'
-  },
-  sortIcon:{
-    base:'glyphicon',
-    up: 'glyphicon-chevron-up',
-    down: 'glyphicon-chevron-down'
-  },
-  onRowClick:function(row) {},
-  filterByColumn:false,
-  highlightMatches:false,
-  orderBy:false,
-  footerHeadings:false,
-  headings:{},
-  pagination: {
-    dropdown:false,
-    chunk:10
-  },
-  serverDataFieldName: 'data'
-}
+    dateColumns:[],
+    listColumns:{},
+    datepickerOptions:{
+      locale: {
+        cancelLabel:'Clear'
+      }
+    },
+    perPage:10,
+    perPageValues:[10,25,50,100],
+    params:{},
+    sortable:[],
+    trackBy:'$index',
+    filterable:false,
+    customFilters:[],
+    templates:{},
+    compileTemplates:false,
+    delay:500,
+    dateFormat:"DD/MM/YYYY",
+    toMomentFormat:false,
+    skin:"table-striped table-bordered table-hover",
+    columnsDisplay: {},
+    texts:{
+      count:"{count} Records",
+      filter:"Filter Results:",
+      filterPlaceholder:"Search query",
+      limit:"Records:",
+      page:"Page:",
+      noResults:"No matching records",
+      filterBy:"Filter by {column}",
+      loading:'Loading...',
+      defaultOption:'Select {column}'
+    },
+    sortIcon:{
+      base:'glyphicon',
+      up: 'glyphicon-chevron-up',
+      down: 'glyphicon-chevron-down'
+    },
+    onRowClick:function(row) {},
+    filterByColumn:false,
+    highlightMatches:false,
+    orderBy:false,
+    footerHeadings:false,
+    headings:{},
+    pagination: {
+      dropdown:false,
+      chunk:10
+    },
+    serverDataFieldName: 'data'
+  }
 }
 
 

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -48,7 +48,8 @@
   pagination: {
     dropdown:false,
     chunk:10
-  }
+  },
+  serverDataFieldName: 'data'
 }
 }
 

--- a/lib/methods/get-data.js
+++ b/lib/methods/get-data.js
@@ -2,18 +2,17 @@ var merge = require('merge');
 
 module.exports = function() {
 
-  var data =  {
-    query:this.query,
-    limit:this.limit,
-    orderBy:this.orderBy.column,
-    ascending: this.orderBy.ascending,
-    page:this.page,
-    byColumn:this.options.filterByColumn?1:0
-  };
+  var data = {};
+  data[this.options.queryParams.query] = this.query;
+  data[this.options.queryParams.limit] = this.limit;
+  data[this.options.queryParams.orderBy] = this.orderBy.column;
+  data[this.options.queryParams.ascending] = this.orderBy.ascending;
+  data[this.options.queryParams.page] = this.page;
+  data[this.options.queryParams.byColumn] = this.options.filterByColumn?1:0;
 
   data = merge(data, this.options.params, this.customQueries);
 
   this.$dispatch('vue-tables.loading', data);
 
-  return this.$http.get(this.url, {params:data});
+  return this.$http.get(this.url, data);
 }

--- a/lib/methods/set-data.js
+++ b/lib/methods/set-data.js
@@ -1,5 +1,5 @@
 module.exports =  function(data) {
-  this.data = data.data;
+  this.data = data[this.options.serverDataFieldName];
   this.count = data.count;
 
   this.addCustomColumns();

--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,8 @@ Javascript:
       }
     });
 
-  All the data is passed in the following GET parameters: `query`,`limit`,`page`,`orderBy`,`ascending`,`byColumn`.
+  All the data is passed in the following GET parameters: `query`,`limit`,`page`,`orderBy`,`ascending`,`byColumn`
+  (change field name via `queryParams` option).  
   You need to return a JSON object with two properties:
 
   `data` `array` - An array of row objects with identical keys (change field name via `serverDataFieldName` option).

--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ Javascript:
   All the data is passed in the following GET parameters: `query`,`limit`,`page`,`orderBy`,`ascending`,`byColumn`.
   You need to return a JSON object with two properties:
 
-  `data` `array` - An array of row objects with identical keys.
+  `data` `array` - An array of row objects with identical keys (change field name via `serverDataFieldName` option).
 
   `count` `number` - Total count before limit.
 


### PR DESCRIPTION
The reply of my API (Django REST Framework default) looks like this:

```json
{   
    "count": 684,
    "next": "http://.../?limit=50&offset=50",
    "previous": null,
    "results": [
         { "foo": "bar" },
         { "foo": "baz" },
    ]
}
```

so I needed an option to change in which field the server table looks for the objects (in this case `results` instead of `data`). In this PR I added that feature. I hope you find it useful.