### PR TITLE
Added rowIndex that can be used in templates function

### DIFF
--- a/lib/filters/render.js
+++ b/lib/filters/render.js
@@ -12,7 +12,7 @@ function getMatches(template) {
   });
 }
 
-module.exports = function(value, row, column) {
+module.exports = function(value, row, column, rowIndex) {
 
   if (this.templatesKeys.indexOf(column)==-1)
     return value;
@@ -20,7 +20,7 @@ module.exports = function(value, row, column) {
   var regex;
 
   if (typeof this.options.templates[column]=='function') {
-    var tpl = this.options.templates[column](row);
+    var tpl = this.options.templates[column](row, rowIndex);
     return wrapTemplate(tpl);
   }
 

--- a/lib/table-template.html
+++ b/lib/table-template.html
@@ -85,9 +85,9 @@
  </tr>
 </tfoot>
 <tbody v-el:tbody>
- <tr v-for="row in data [[rowFilters]]" [[trackBy]] @click='options.onRowClick(row)'>
+ <tr v-for="(rowIndex, row) in data [[rowFilters]]" [[trackBy]] @click='options.onRowClick(row)'>
    <td v-for="column in allColumns"
-   v-html="row[column] | render row column [[columnFilters]]"></td>
+   v-html="row[column] | render row column rowIndex [[columnFilters]]"></td>
  </tr>
 
  <tr v-if="count==0"


### PR DESCRIPTION
In my project I needed the rowIndex in my template function. This can only be added in the vue-tables source.   I thought maybe also someone else might need this. So I created this pull request. I'd be happy if you accept it. It is a very small and simple change.

Did I already mention that vue-tables is awesome! :-)