### PR TITLE
Allow to use a custom template

### DIFF
--- a/lib/helpers/generate-table-html.js
+++ b/lib/helpers/generate-table-html.js
@@ -1,6 +1,5 @@
-module.exports = function(replacements) {
-
-  var template = require('../table-template.html');
+module.exports = function(replacements, template) {
+  template = template || require('../table-template.html');
 
   for (var replacement in replacements) {
     template = template.replace("[[" + replacement + "]]", replacements[replacement]);

--- a/lib/v-client-table.js
+++ b/lib/v-client-table.js
@@ -6,7 +6,7 @@ var created = require('./mixins/created');
 var template = require('./helpers/generate-table-html');
 var VuePagination = require('v-pagination');
 
-exports.install = function(Vue, globalOptions) {
+exports.install = function(Vue, globalOptions, customOptions) {
 
   Vue.use(VuePagination);
 
@@ -18,7 +18,7 @@ exports.install = function(Vue, globalOptions) {
       trackBy:':track-by="options.trackBy"',
       columnFilters:'| date | optionText column | highlightMatches column',
       loading:''
-    }),
+    }, customOptions.template),
     mixins:[data, methods, filters, computed, created],
     props: {
       columns:{

--- a/lib/v-client-table.js
+++ b/lib/v-client-table.js
@@ -10,6 +10,10 @@ exports.install = function(Vue, globalOptions, customOptions) {
 
   Vue.use(VuePagination);
 
+  var customTemplate = customOptions && customOptions.template
+    ? customOptions.template
+    : undefined;
+
   var client = {
 
     template: template({
@@ -18,7 +22,7 @@ exports.install = function(Vue, globalOptions, customOptions) {
       trackBy:':track-by="options.trackBy"',
       columnFilters:'| date | optionText column | highlightMatches column',
       loading:''
-    }, customOptions.template),
+    }, customTemplate),
     mixins:[data, methods, filters, computed, created],
     props: {
       columns:{

--- a/lib/v-server-table.js
+++ b/lib/v-server-table.js
@@ -10,6 +10,10 @@ exports.install = function(Vue, globalOptions, customOptions) {
 
   Vue.use(VuePagination);
 
+  var customTemplate = customOptions && customOptions.template
+    ? customOptions.template
+    : undefined;
+
   var server = {
     template: template({
       source:'Server',
@@ -17,7 +21,7 @@ exports.install = function(Vue, globalOptions, customOptions) {
       trackBy:'',
       columnFilters:'| optionText column | highlightMatches column',
       loading:"loading?'loading':"
-    }, customOptions.template),
+    }, customTemplate),
     mixins:[data, methods, filters,computed, created],
     props: {
      columns:{

--- a/lib/v-server-table.js
+++ b/lib/v-server-table.js
@@ -6,7 +6,7 @@ var created = require('./mixins/created');
 var template = require('./helpers/generate-table-html');
 var VuePagination = require('v-pagination');
 
-exports.install = function(Vue, globalOptions) {
+exports.install = function(Vue, globalOptions, customOptions) {
 
   Vue.use(VuePagination);
 
@@ -17,7 +17,7 @@ exports.install = function(Vue, globalOptions) {
       trackBy:'',
       columnFilters:'| optionText column | highlightMatches column',
       loading:"loading?'loading':"
-    }),
+    }, customOptions.template),
     mixins:[data, methods, filters,computed, created],
     props: {
      columns:{


### PR DESCRIPTION
This allows to use a custom template provided on compilation level, like so:

```js
Vue.use(VueTables.client, {}, { template: require('./my-vue-table-template') });
```