### PR TITLE
define datepickerOptions per column

### DIFF
--- a/lib/methods/init-date-filters.js
+++ b/lib/methods/init-date-filters.js
@@ -32,6 +32,10 @@ module.exports = function() {
 
        el.text(initialValues.startDate + " - " + initialValues.endDate);
       }
+     
+     if (that.options.columnsDatepickerOptions && that.options.columnsDatepickerOptions[column]) {
+       datepickerOptions = merge.recursive(that.options.columnsDatepickerOptions[column],datepickerOptions);
+     }
 
      el.daterangepicker(merge.recursive(datepickerOptions, initialValues));
      el.on('apply.daterangepicker', function(ev, picker) {

--- a/lib/methods/init-date-filters.js
+++ b/lib/methods/init-date-filters.js
@@ -33,8 +33,8 @@ module.exports = function() {
        el.text(initialValues.startDate + " - " + initialValues.endDate);
       }
      
-     if (that.options.columnsDatepickerOptions && that.options.columnsDatepickerOptions[column]) {
-       datepickerOptions = merge.recursive(datepickerOptions,that.options.columnsDatepickerOptions[column]);
+     if (that.options.perColumnDatepickerOptions && that.options.perColumnDatepickerOptions[column]) {
+       var datepickerOptions = merge.recursive(datepickerOptions,that.options.perColumnDatepickerOptions[column]);
      }
 
      el.daterangepicker(merge.recursive(datepickerOptions, initialValues));

--- a/lib/methods/init-date-filters.js
+++ b/lib/methods/init-date-filters.js
@@ -34,7 +34,7 @@ module.exports = function() {
       }
      
      if (that.options.columnsDatepickerOptions && that.options.columnsDatepickerOptions[column]) {
-       datepickerOptions = merge.recursive(that.options.columnsDatepickerOptions[column],datepickerOptions);
+       datepickerOptions = merge.recursive(datepickerOptions,that.options.columnsDatepickerOptions[column]);
      }
 
      el.daterangepicker(merge.recursive(datepickerOptions, initialValues));


### PR DESCRIPTION
This patch make defining all the datepickerOptions per column possible.
To mantain backward compatibility I suggest to use a new option "columnsDatepickerOptions", and I've kept the "initialValues" approach which works fine but is limited to startDate and endDate options.